### PR TITLE
Use utf-8 to load textual metadata files.

### DIFF
--- a/src/LtMAO/cslmao.py
+++ b/src/LtMAO/cslmao.py
@@ -60,7 +60,7 @@ def delete_mod(mod):
 
 def get_info(mod):
     info_file = os.path.join(raw_dir, mod.get_path(), 'META', 'info.json')
-    with open(info_file, 'r') as f:
+    with open(info_file, 'r', encoding='utf-8') as f:
         info = json.load(f)
     image_path = None
     image_file = os.path.join(raw_dir, mod.get_path(), 'META', 'image.png')
@@ -93,7 +93,7 @@ def load_mods():
     # load through mod file
     try:
         l = []
-        with open(mod_file, 'r') as f:
+        with open(mod_file, 'r', encoding='utf-8') as f:
             l = json.load(f)
         MOD.mods = [MOD(id, path, enable, profile) for id, path, enable, profile in l]
     except Exception as e:


### PR DESCRIPTION
Some META/info.json files contain utf-8 only characters. There are some encodings this will fail cause issues with, but by default `open` uses the locale default encoding, which is rarely correct. Should not cause any issues for any json files encoding non ascii codepoints using \u escapes, and all other ones are a lost cause where utf-8 is the best shot.

https://utf8everywhere.org/