### PR TITLE
Support skeletons with more than 256 joints in SKN/SKL export

### DIFF
--- a/src/LtMAO/lemon3d/lemon_fbx/__init__.py
+++ b/src/LtMAO/lemon3d/lemon_fbx/__init__.py
@@ -35,12 +35,16 @@ def fbx_to_skin(fbx_path, skl_path, skn_path, anm_path):
 
     # dump skl
     skl, blender_armature_node_name, blender_armature_node_local_matrix = skin.SKL.dump_skl(fbx_joints)
+
+    # dump skn
+    # this also builds skl.influences out of the weighted joints,
+    # so skl must be written after the skn dump
+    skn = skin.SKN.dump_skn(fbx_meshes, skl, blender_armature_node_name, blender_armature_node_local_matrix)
+
+    # write skl + skn
     helper.mirrorX(skl=skl)
     skl.write(skl_path)
     print(f'lemon_fbx: Finish: Write SKL: {skl_path}')
-
-    # dump skn
-    skn = skin.SKN.dump_skn(fbx_meshes, skl, blender_armature_node_name, blender_armature_node_local_matrix)
     helper.mirrorX(skn=skn)
     skn.write(skn_path)
     print(f'lemon_fbx: Finish: Write SKN: {skn_path}')

--- a/src/LtMAO/lemon3d/lemon_fbx/skin.py
+++ b/src/LtMAO/lemon3d/lemon_fbx/skin.py
@@ -36,9 +36,11 @@ class SKL:
     @staticmethod
     def dump_skl(fbx_joints):
         # prepare
+        # only weighted joints are limited to 256 (checked on skn dump),
+        # the skeleton itself can hold up to 65535 joints
         joint_count = len(fbx_joints)
-        if joint_count > 256:
-            raise Exception(f'lemon_fbx: Error: Too many joints found: {joint_count}, max: 256')
+        if joint_count > 65535:
+            raise Exception(f'lemon_fbx: Error: Too many joints found: {joint_count}, max: 65535')
         skl = pyRitoFile.skl.SKL()
         skl.joints = [pyRitoFile.skl.SKLJoint() for i in range(joint_count)]
         # dump joint infos
@@ -407,6 +409,14 @@ class SKN:
         
         if len(skn.vertices) > 65535:
             raise Exception(f'lemon_fbx: Error: Too many vertices found: {len(skn.vertices)}, max allowed: 65535 vertices. (base on UVs)')
+
+        # build skl influences out of the weighted joints and
+        # remap vertex joint ids -> influence slot bytes
+        try:
+            skl.influences = pyRitoFile.skn.build_influences(skn.vertices, skl.joints)
+        except ValueError as e:
+            raise Exception(f'lemon_fbx: Error: {e}')
+
         print(f'lemon_fbx: Finish: Dump SKN.')
         return skn
 

--- a/src/LtMAO/lemon3d/lemon_maya/plugins/translator/skin.py
+++ b/src/LtMAO/lemon3d/lemon_maya/plugins/translator/skin.py
@@ -164,9 +164,9 @@ class SkinExporter(MPxFileTranslator):
             }
             skl = pyRitoFile.skl.SKL()
             SKL.scene_dump(skl, dump_options)
-            helper.mirrorX(skl=skl)
-            skl.write(skl_path)
             # dump skn
+            # this also builds skl.influences out of the weighted joints,
+            # so skl must be written after the skn dump
             riot_skn = None
             riot_skn_path = helper.get_riot_path(skn_path)
             if riot_skn_path != '':
@@ -178,6 +178,9 @@ class SkinExporter(MPxFileTranslator):
                 'riot_skn': riot_skn
             }
             SKN.scene_dump(skn, dump_options)
+            # write
+            helper.mirrorX(skl=skl)
+            skl.write(skl_path)
             helper.mirrorX(skn=skn)
             skn.write(skn_path)
         
@@ -238,6 +241,11 @@ class SKLExporter(MPxFileTranslator):
             }
             skl = pyRitoFile.skl.SKL()
             SKL.scene_dump(skl, dump_options)
+            # no skn dumped along = no weighted joints known to build influences from
+            # -> reuse riot.skl influences (joints are sorted to riot order so they stay valid)
+            # -> otherwise pyRitoFile falls back to identity influences on write
+            if riot_skl != None and riot_skl.influences != None:
+                skl.influences = list(riot_skl.influences)
             helper.mirrorX(skl=skl)
             skl.write(skl_path)
             return True
@@ -652,7 +660,8 @@ class SKN:
                                 position.x, position.y, position.z)
                             vertex.normal = pyRitoFile.structs.Vector(
                                 normal.x, normal.y, normal.z)
-                            vertex.influences = bytes(influences)
+                            # joint ids for now, remapped to influence slot bytes after all meshes are dumped
+                            vertex.influences = influences
                             vertex.weights = vertex_weights
                             vertex.uv = uv
                             vertex.uv_index = uv_index
@@ -834,6 +843,14 @@ class SKN:
             raise helper.FunnyError(
                 f'SKN Exporter: Too many materials assigned: {submesh_count}, max allowed: 32 materials.')
 
+        # build skl influences out of the weighted joints and
+        # remap vertex joint ids -> influence slot bytes
+        try:
+            skl.influences = pyRitoFile.skn.build_influences(
+                skn.vertices, skl.joints)
+        except ValueError as e:
+            raise helper.FunnyError(f'SKN Exporter: {e}')
+
 class SKL:
     @staticmethod
     def scene_load(skl, load_options):
@@ -864,18 +881,27 @@ class SKL:
                 # get the existed joint
                 ik_joint = MFnIkJoint(joint.dagpath)
             # add custom attribute: Riot ID
-            if not cmds.attributeQuery(
+            attribute_exists = cmds.attributeQuery(
                 'riotid',
                 exists=True,
                 node=joint.name
-            ):
+            )
+            if attribute_exists and cmds.attributeQuery(
+                'riotid',
+                node=joint.name,
+                attributeType=True
+            ) == 'byte':
+                # older versions created riotid as byte which cant hold ids above 255
+                cmds.deleteAttr(f'{joint.name}.riotid')
+                attribute_exists = False
+            if not attribute_exists:
                 cmds.addAttr(
                     joint.name,
                     longName='riotid',
                     niceName='Riot ID',
-                    attributeType='byte',
-                    minValue=0, 
-                    maxValue=255, 
+                    attributeType='long',
+                    minValue=0,
+                    maxValue=65535,
                     defaultValue=joint_id
                 )
             cmds.setAttr(f'{joint.name}.riotid', joint_id)
@@ -1053,7 +1079,9 @@ class SKL:
                 joint.parent = -1
 
         # check limit joint
+        # only weighted joints are limited to 256 (checked on skn dump),
+        # the skeleton itself can hold up to 65535 joints
         joint_count = len(skl.joints)
-        if joint_count > 256:
+        if joint_count > 65535:
             raise helper.FunnyError(
-                f'SKL Exporter: Too many joints found: {joint_count}, max allowed: 256 joints.')
+                f'SKL Exporter: Too many joints found: {joint_count}, max allowed: 65535 joints.')

--- a/src/LtMAO/pyRitoFile/skl.py
+++ b/src/LtMAO/pyRitoFile/skl.py
@@ -167,14 +167,33 @@ class SKL:
             bs.write_u32(0, 0x22FD4FC3, 0)
 
             joint_count = len(self.joints)
+            if joint_count > 65535:
+                raise Exception(
+                    f'pyRitoFile: Error: Write SKL {path}: Too many joints: {joint_count}, max allowed: 65535 joints.')
+            
+            # SKN vertex blend indices are bytes that index the influence table,
+            # the table then maps each slot (max 256) to a joint id (max 65535)
+            influences = self.influences
+            if influences == None:
+                # no influences set -> identity table over all joints (old behavior)
+                if joint_count > 256:
+                    raise Exception(
+                        f'pyRitoFile: Error: Write SKL {path}: {joint_count} joints (>256) but no influences set: set SKL.influences to the list of weighted joint ids (max 256).')
+                influences = list(range(joint_count))
+            
+            influence_count = len(influences)
+            if influence_count > 256:
+                raise Exception(
+                    f'pyRitoFile: Error: Write SKL {path}: Too many influences: {influence_count}, max allowed: 256 influences.')
+            
             bs.write_u16(0)  # flags
             bs.write_u16(joint_count)
-            bs.write_u32(joint_count)
+            bs.write_u32(influence_count)
 
             joints_offset = 64
             joint_indices_offset = joints_offset + joint_count * 100
             influences_offset = joint_indices_offset + joint_count * 8
-            joint_names_offset = influences_offset + joint_count * 2
+            joint_names_offset = influences_offset + influence_count * 2
 
             bs.write_i32(
                 joints_offset,
@@ -217,12 +236,13 @@ class SKL:
 
             # influences
             bs.seek(influences_offset)
-            bs.write_u16(*[i for i in range(joint_count)])
+            if influence_count > 0:
+                bs.write_u16(*influences)
 
-            # joint indices
+            # joint indices, sorted by hash ascending
             bs.seek(joint_indices_offset)
-            for i in range(joint_count):
-                bs.write_u16(i)
+            for joint_id, joint in sorted(enumerate(self.joints), key=lambda x: x[1].hash):
+                bs.write_u16(joint_id)
                 bs.write_u16(0)  # pad
                 bs.write_u32(joint.hash)
 

--- a/src/LtMAO/pyRitoFile/skn.py
+++ b/src/LtMAO/pyRitoFile/skn.py
@@ -52,6 +52,49 @@ class SKNSubmesh:
         return {key: getattr(self, key) for key in self.__slots__}
 
 
+def build_influences(vertices, joints=None):
+    # build the skl influence table out of the weighted joint ids in vertices,
+    # then remap each vertex's influences from joint ids to influence slot bytes
+    # vertex blend indices are bytes indexing the skl influence table (max 256 slots),
+    # each slot maps to a joint id, so joints above id 255 can still be weighted
+    # returns the influence table to store on SKL.influences
+    joint_usage = {}  # joint id -> [total weight, weighted vertex count]
+    for vertex in vertices:
+        for i in range(4):
+            if vertex.weights[i] > 0.0:
+                usage = joint_usage.setdefault(vertex.influences[i], [0.0, 0])
+                usage[0] += vertex.weights[i]
+                usage[1] += 1
+
+    influence_table = sorted(joint_usage) if len(joint_usage) > 0 else [0]
+    if len(influence_table) > 256:
+        over_count = len(influence_table) - 256
+        # suggest removing the joints that matter the least on the mesh
+        least_used = sorted(joint_usage, key=lambda joint_id: joint_usage[joint_id])[:over_count]
+        lines = []
+        for joint_id in least_used[:10]:
+            name = joints[joint_id].name if joints != None else f'joint {joint_id}'
+            total_weight, vertex_count = joint_usage[joint_id]
+            lines.append(f'- {name}: {vertex_count} vertices, {total_weight:.3f} total weight')
+        
+        if over_count > 10:
+            lines.append(f'- ... and {over_count - 10} more')
+        
+        raise ValueError(
+            f'Too many weighted joints: {len(influence_table)}, max allowed: 256 weighted joints. (unweighted joints dont count, the skeleton can hold up to 65535 joints)\n'
+            f'Remove weights on at least {over_count} joints, these are the least used ones:\n'
+            + '\n'.join(lines))
+
+    slot_by_joint = {joint_id: slot for slot, joint_id in enumerate(influence_table)}
+    for vertex in vertices:
+        vertex.influences = bytes(
+            slot_by_joint[vertex.influences[i]] if vertex.weights[i] > 0.0 else 0
+            for i in range(4)
+        )
+    
+    return influence_table
+
+
 class SKN:
     __slots__ = (
         'signature', 'version', 'flags',

--- a/src/LtMAO/sborf.py
+++ b/src/LtMAO/sborf.py
@@ -13,6 +13,8 @@ def skin_fix(skl_path, skn_path, riotskl_path, riotskn_path='', backup=True, don
     print(f'sborf: Finish: Read SKIN.')
 
     # sort joint
+    old_influences = skl.influences if skl.influences != None else list(
+        range(len(skl.joints)))
     new_joint_id_by_old_joint_id = {}
     new_joint_id_by_old_joint_id[-1] = -1  # for parent
     print(f'sborf: Start:  Sort joints.')
@@ -66,16 +68,17 @@ def skin_fix(skl_path, skn_path, riotskl_path, riotskn_path='', backup=True, don
     # sort parent
     for joint in skl.joints:
         joint.parent = new_joint_id_by_old_joint_id[joint.parent]
-    if len(skl.joints) > 256:
+    if len(skl.joints) > 65535:
         raise Exception(
-            f'sborf: Error: Sort joints: Too many joints after sort: {len(skn.joints)}(>256), please check if Riot SKL is correct.')
+            f'sborf: Error: Sort joints: Too many joints after sort: {len(skl.joints)}(>65535), please check if Riot SKL is correct.')
     print(f'sborf: Finish: Sort joints.')
 
     # update influences
+    # skn vertex blend indices index the skl influence table, not the joints,
+    # so remap the joint ids inside the table and the vertices stay untouched
     print(f'sborf: Start:  Update influences.')
-    for vertex in skn.vertices:
-        vertex.influences = [new_joint_id_by_old_joint_id[inf]
-                             for inf in vertex.influences]
+    skl.influences = [new_joint_id_by_old_joint_id[inf]
+                      for inf in old_influences]
     print(f'sborf: Finish: Update influences.')
 
     # sort materials


### PR DESCRIPTION
Riot's newest skins exceed 256 joints - MF skin69 (legendary) has 260
joints with a compacted 199-entry influence table whose slots reference
joint ids up to 259. Importing it works, but re-exporting crashes with
a bone-limit error even though the file is perfectly valid.

### Root cause

The 256 limit in the SKN format applies to **influence slots**, not
joint ids: vertex blend indices are `u8` into the SKL influence table,
and the table's `u16` entries map each slot to a joint id (skeleton max
65535). The exporters collapsed the two index spaces: they wrote raw
joint ids into the vertex bytes and an identity influence table
(`0, 1, 2, ...`), which silently caps the whole skeleton at 256 joints - and 
`bytes()` throws the moment a weighted joint id exceeds 255.