### PR TITLE
Pyntex fix, and .ritobin support

### DIFF
--- a/src/LtMAO/lemon3d/lemon_fbx/__init__.py
+++ b/src/LtMAO/lemon3d/lemon_fbx/__init__.py
@@ -35,12 +35,16 @@ def fbx_to_skin(fbx_path, skl_path, skn_path, anm_path):
 
     # dump skl
     skl, blender_armature_node_name, blender_armature_node_local_matrix = skin.SKL.dump_skl(fbx_joints)
+
+    # dump skn
+    # this also builds skl.influences out of the weighted joints,
+    # so skl must be written after the skn dump
+    skn = skin.SKN.dump_skn(fbx_meshes, skl, blender_armature_node_name, blender_armature_node_local_matrix)
+
+    # write skl + skn
     helper.mirrorX(skl=skl)
     skl.write(skl_path)
     print(f'lemon_fbx: Finish: Write SKL: {skl_path}')
-
-    # dump skn
-    skn = skin.SKN.dump_skn(fbx_meshes, skl, blender_armature_node_name, blender_armature_node_local_matrix)
     helper.mirrorX(skn=skn)
     skn.write(skn_path)
     print(f'lemon_fbx: Finish: Write SKN: {skn_path}')

--- a/src/LtMAO/lemon3d/lemon_fbx/skin.py
+++ b/src/LtMAO/lemon3d/lemon_fbx/skin.py
@@ -36,9 +36,11 @@ class SKL:
     @staticmethod
     def dump_skl(fbx_joints):
         # prepare
+        # only weighted joints are limited to 256 (checked on skn dump),
+        # the skeleton itself can hold up to 65535 joints
         joint_count = len(fbx_joints)
-        if joint_count > 256:
-            raise Exception(f'lemon_fbx: Error: Too many joints found: {joint_count}, max: 256')
+        if joint_count > 65535:
+            raise Exception(f'lemon_fbx: Error: Too many joints found: {joint_count}, max: 65535')
         skl = pyRitoFile.skl.SKL()
         skl.joints = [pyRitoFile.skl.SKLJoint() for i in range(joint_count)]
         # dump joint infos
@@ -407,6 +409,14 @@ class SKN:
         
         if len(skn.vertices) > 65535:
             raise Exception(f'lemon_fbx: Error: Too many vertices found: {len(skn.vertices)}, max allowed: 65535 vertices. (base on UVs)')
+
+        # build skl influences out of the weighted joints and
+        # remap vertex joint ids -> influence slot bytes
+        try:
+            skl.influences = pyRitoFile.skn.build_influences(skn.vertices, skl.joints)
+        except ValueError as e:
+            raise Exception(f'lemon_fbx: Error: {e}')
+
         print(f'lemon_fbx: Finish: Dump SKN.')
         return skn
 

--- a/src/LtMAO/lemon3d/lemon_maya/plugins/translator/skin.py
+++ b/src/LtMAO/lemon3d/lemon_maya/plugins/translator/skin.py
@@ -164,9 +164,9 @@ class SkinExporter(MPxFileTranslator):
             }
             skl = pyRitoFile.skl.SKL()
             SKL.scene_dump(skl, dump_options)
-            helper.mirrorX(skl=skl)
-            skl.write(skl_path)
             # dump skn
+            # this also builds skl.influences out of the weighted joints,
+            # so skl must be written after the skn dump
             riot_skn = None
             riot_skn_path = helper.get_riot_path(skn_path)
             if riot_skn_path != '':
@@ -178,6 +178,9 @@ class SkinExporter(MPxFileTranslator):
                 'riot_skn': riot_skn
             }
             SKN.scene_dump(skn, dump_options)
+            # write
+            helper.mirrorX(skl=skl)
+            skl.write(skl_path)
             helper.mirrorX(skn=skn)
             skn.write(skn_path)
         
@@ -238,6 +241,11 @@ class SKLExporter(MPxFileTranslator):
             }
             skl = pyRitoFile.skl.SKL()
             SKL.scene_dump(skl, dump_options)
+            # no skn dumped along = no weighted joints known to build influences from
+            # -> reuse riot.skl influences (joints are sorted to riot order so they stay valid)
+            # -> otherwise pyRitoFile falls back to identity influences on write
+            if riot_skl != None and riot_skl.influences != None:
+                skl.influences = list(riot_skl.influences)
             helper.mirrorX(skl=skl)
             skl.write(skl_path)
             return True
@@ -652,7 +660,8 @@ class SKN:
                                 position.x, position.y, position.z)
                             vertex.normal = pyRitoFile.structs.Vector(
                                 normal.x, normal.y, normal.z)
-                            vertex.influences = bytes(influences)
+                            # joint ids for now, remapped to influence slot bytes after all meshes are dumped
+                            vertex.influences = influences
                             vertex.weights = vertex_weights
                             vertex.uv = uv
                             vertex.uv_index = uv_index
@@ -834,6 +843,14 @@ class SKN:
             raise helper.FunnyError(
                 f'SKN Exporter: Too many materials assigned: {submesh_count}, max allowed: 32 materials.')
 
+        # build skl influences out of the weighted joints and
+        # remap vertex joint ids -> influence slot bytes
+        try:
+            skl.influences = pyRitoFile.skn.build_influences(
+                skn.vertices, skl.joints)
+        except ValueError as e:
+            raise helper.FunnyError(f'SKN Exporter: {e}')
+
 class SKL:
     @staticmethod
     def scene_load(skl, load_options):
@@ -864,18 +881,27 @@ class SKL:
                 # get the existed joint
                 ik_joint = MFnIkJoint(joint.dagpath)
             # add custom attribute: Riot ID
-            if not cmds.attributeQuery(
+            attribute_exists = cmds.attributeQuery(
                 'riotid',
                 exists=True,
                 node=joint.name
-            ):
+            )
+            if attribute_exists and cmds.attributeQuery(
+                'riotid',
+                node=joint.name,
+                attributeType=True
+            ) == 'byte':
+                # older versions created riotid as byte which cant hold ids above 255
+                cmds.deleteAttr(f'{joint.name}.riotid')
+                attribute_exists = False
+            if not attribute_exists:
                 cmds.addAttr(
                     joint.name,
                     longName='riotid',
                     niceName='Riot ID',
-                    attributeType='byte',
-                    minValue=0, 
-                    maxValue=255, 
+                    attributeType='long',
+                    minValue=0,
+                    maxValue=65535,
                     defaultValue=joint_id
                 )
             cmds.setAttr(f'{joint.name}.riotid', joint_id)
@@ -1053,7 +1079,9 @@ class SKL:
                 joint.parent = -1
 
         # check limit joint
+        # only weighted joints are limited to 256 (checked on skn dump),
+        # the skeleton itself can hold up to 65535 joints
         joint_count = len(skl.joints)
-        if joint_count > 256:
+        if joint_count > 65535:
             raise helper.FunnyError(
-                f'SKL Exporter: Too many joints found: {joint_count}, max allowed: 256 joints.')
+                f'SKL Exporter: Too many joints found: {joint_count}, max allowed: 65535 joints.')

--- a/src/LtMAO/pyRitoFile/skl.py
+++ b/src/LtMAO/pyRitoFile/skl.py
@@ -167,14 +167,33 @@ class SKL:
             bs.write_u32(0, 0x22FD4FC3, 0)
 
             joint_count = len(self.joints)
+            if joint_count > 65535:
+                raise Exception(
+                    f'pyRitoFile: Error: Write SKL {path}: Too many joints: {joint_count}, max allowed: 65535 joints.')
+            
+            # SKN vertex blend indices are bytes that index the influence table,
+            # the table then maps each slot (max 256) to a joint id (max 65535)
+            influences = self.influences
+            if influences == None:
+                # no influences set -> identity table over all joints (old behavior)
+                if joint_count > 256:
+                    raise Exception(
+                        f'pyRitoFile: Error: Write SKL {path}: {joint_count} joints (>256) but no influences set: set SKL.influences to the list of weighted joint ids (max 256).')
+                influences = list(range(joint_count))
+            
+            influence_count = len(influences)
+            if influence_count > 256:
+                raise Exception(
+                    f'pyRitoFile: Error: Write SKL {path}: Too many influences: {influence_count}, max allowed: 256 influences.')
+            
             bs.write_u16(0)  # flags
             bs.write_u16(joint_count)
-            bs.write_u32(joint_count)
+            bs.write_u32(influence_count)
 
             joints_offset = 64
             joint_indices_offset = joints_offset + joint_count * 100
             influences_offset = joint_indices_offset + joint_count * 8
-            joint_names_offset = influences_offset + joint_count * 2
+            joint_names_offset = influences_offset + influence_count * 2
 
             bs.write_i32(
                 joints_offset,
@@ -217,12 +236,13 @@ class SKL:
 
             # influences
             bs.seek(influences_offset)
-            bs.write_u16(*[i for i in range(joint_count)])
+            if influence_count > 0:
+                bs.write_u16(*influences)
 
-            # joint indices
+            # joint indices, sorted by hash ascending
             bs.seek(joint_indices_offset)
-            for i in range(joint_count):
-                bs.write_u16(i)
+            for joint_id, joint in sorted(enumerate(self.joints), key=lambda x: x[1].hash):
+                bs.write_u16(joint_id)
                 bs.write_u16(0)  # pad
                 bs.write_u32(joint.hash)
 

--- a/src/LtMAO/pyRitoFile/skn.py
+++ b/src/LtMAO/pyRitoFile/skn.py
@@ -52,6 +52,49 @@ class SKNSubmesh:
         return {key: getattr(self, key) for key in self.__slots__}
 
 
+def build_influences(vertices, joints=None):
+    # build the skl influence table out of the weighted joint ids in vertices,
+    # then remap each vertex's influences from joint ids to influence slot bytes
+    # vertex blend indices are bytes indexing the skl influence table (max 256 slots),
+    # each slot maps to a joint id, so joints above id 255 can still be weighted
+    # returns the influence table to store on SKL.influences
+    joint_usage = {}  # joint id -> [total weight, weighted vertex count]
+    for vertex in vertices:
+        for i in range(4):
+            if vertex.weights[i] > 0.0:
+                usage = joint_usage.setdefault(vertex.influences[i], [0.0, 0])
+                usage[0] += vertex.weights[i]
+                usage[1] += 1
+
+    influence_table = sorted(joint_usage) if len(joint_usage) > 0 else [0]
+    if len(influence_table) > 256:
+        over_count = len(influence_table) - 256
+        # suggest removing the joints that matter the least on the mesh
+        least_used = sorted(joint_usage, key=lambda joint_id: joint_usage[joint_id])[:over_count]
+        lines = []
+        for joint_id in least_used[:10]:
+            name = joints[joint_id].name if joints != None else f'joint {joint_id}'
+            total_weight, vertex_count = joint_usage[joint_id]
+            lines.append(f'- {name}: {vertex_count} vertices, {total_weight:.3f} total weight')
+        
+        if over_count > 10:
+            lines.append(f'- ... and {over_count - 10} more')
+        
+        raise ValueError(
+            f'Too many weighted joints: {len(influence_table)}, max allowed: 256 weighted joints. (unweighted joints dont count, the skeleton can hold up to 65535 joints)\n'
+            f'Remove weights on at least {over_count} joints, these are the least used ones:\n'
+            + '\n'.join(lines))
+
+    slot_by_joint = {joint_id: slot for slot, joint_id in enumerate(influence_table)}
+    for vertex in vertices:
+        vertex.influences = bytes(
+            slot_by_joint[vertex.influences[i]] if vertex.weights[i] > 0.0 else 0
+            for i in range(4)
+        )
+    
+    return influence_table
+
+
 class SKN:
     __slots__ = (
         'signature', 'version', 'flags',

--- a/src/LtMAO/pyntex.py
+++ b/src/LtMAO/pyntex.py
@@ -31,7 +31,10 @@ def parse_bin(bin, *, existing_files={}):
         missing_files = []
 
         def parse_value(value, value_type):
-            if value_type == pyRitoFile.bin.BINType.STRING:
+            if value_type in (
+                pyRitoFile.bin.BINType.STRING,
+                pyRitoFile.bin.BINType.FILE,
+            ):
                 value = value.lower()
                 if 'assets/' in value or 'data/' in value:
                     if value not in mentioned_files:
@@ -56,7 +59,18 @@ def parse_bin(bin, *, existing_files={}):
                 for key, value in field.data.items():
                     parse_value(key, field.key_type)
                     parse_value(value, field.value_type)
-            elif field.type == pyRitoFile.bin.BINType.OPTION and field.value_type == pyRitoFile.bin.BINType.STRING:
+            elif field.type == pyRitoFile.bin.BINType.OPTION and field.value_type in (
+                pyRitoFile.bin.BINType.STRING,
+                pyRitoFile.bin.BINType.FILE,
+            ):
+                if field.data != None:
+                    value = field.data
+                    if field.value_type == pyRitoFile.bin.BINType.FILE:
+                        value = pyRitoFile.bin.BINHasher.hex_to_raw(
+                            hash_helper.Storage.hashtables,
+                            value
+                        )
+                    parse_value(value, field.value_type)
                 if field.data != None:
                     parse_value(field.data, field.value_type)
             else:
@@ -112,6 +126,8 @@ def parse_dir(path, delete_junk_files=False):
     # parsing
     print(f'pyntex: Start:  Read bin hashes')
     hash_helper.Storage.read_bin_hashes()
+    print(f'pyntex: Start:  Read wad hashes')
+    hash_helper.Storage.read_wad_hashes()
     for full_file_index, full_file in enumerate(full_files):
         if full_file.endswith('.bin'):
             try:

--- a/src/LtMAO/sborf.py
+++ b/src/LtMAO/sborf.py
@@ -13,6 +13,8 @@ def skin_fix(skl_path, skn_path, riotskl_path, riotskn_path='', backup=True, don
     print(f'sborf: Finish: Read SKIN.')
 
     # sort joint
+    old_influences = skl.influences if skl.influences != None else list(
+        range(len(skl.joints)))
     new_joint_id_by_old_joint_id = {}
     new_joint_id_by_old_joint_id[-1] = -1  # for parent
     print(f'sborf: Start:  Sort joints.')
@@ -66,16 +68,17 @@ def skin_fix(skl_path, skn_path, riotskl_path, riotskn_path='', backup=True, don
     # sort parent
     for joint in skl.joints:
         joint.parent = new_joint_id_by_old_joint_id[joint.parent]
-    if len(skl.joints) > 256:
+    if len(skl.joints) > 65535:
         raise Exception(
-            f'sborf: Error: Sort joints: Too many joints after sort: {len(skn.joints)}(>256), please check if Riot SKL is correct.')
+            f'sborf: Error: Sort joints: Too many joints after sort: {len(skl.joints)}(>65535), please check if Riot SKL is correct.')
     print(f'sborf: Finish: Sort joints.')
 
     # update influences
+    # skn vertex blend indices index the skl influence table, not the joints,
+    # so remap the joint ids inside the table and the vertices stay untouched
     print(f'sborf: Start:  Update influences.')
-    for vertex in skn.vertices:
-        vertex.influences = [new_joint_id_by_old_joint_id[inf]
-                             for inf in vertex.influences]
+    skl.influences = [new_joint_id_by_old_joint_id[inf]
+                      for inf in old_influences]
     print(f'sborf: Finish: Update influences.')
 
     # sort materials

--- a/src/LtMAO/winLT.py
+++ b/src/LtMAO/winLT.py
@@ -18,6 +18,7 @@ class Context:
             'ZipFantome': True,
             'RitobinDirToPy': True,
             'RitobinDirToBin': True,
+            'PyToRitobinDir': True,
             'tex2ddsdir': True,
             'dds2texdir': True,
             'dir2bnk': True,
@@ -43,6 +44,7 @@ class Context:
         },
         'py': {
             'RitobinToBin': True,
+            'PyToRitobin': True,
         },
         'rito': {
             'RitobinToBin': True,
@@ -141,6 +143,14 @@ class Context:
         'RitobinDirToBin': {
             'desc': 'ritobin: Convert All PY To BIN',
             'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="ritobindir2bin" -src="%V"'
+        },
+        'PyToRitobinDir': {
+            'desc': 'ritobin: Rename All PY To RITOBIN',
+            'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="py2ritobin" -src="%V"'
+        },
+        'PyToRitobin': {
+            'desc': 'ritobin: Rename To RITOBIN',
+            'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="py2ritobin" -src="%V"'
         },
         'LFI': {
             'desc': 'file_inspector: Print infos as JSON',

--- a/src/LtMAO/winLT.py
+++ b/src/LtMAO/winLT.py
@@ -19,6 +19,7 @@ class Context:
             'RitobinDirToPy': True,
             'RitobinDirToBin': True,
             'PyToRitobinDir': True,
+            'RitobinToPyDir': True,
             'tex2ddsdir': True,
             'dds2texdir': True,
             'dir2bnk': True,
@@ -48,9 +49,11 @@ class Context:
         },
         'rito': {
             'RitobinToBin': True,
+            'RitobinToPy': True,
         },
         'ritobin': {
             'RitobinToBin': True,
+            'RitobinToPy': True,
         },
         'skl': {
             'hashextract': True,
@@ -151,6 +154,14 @@ class Context:
         'PyToRitobin': {
             'desc': 'ritobin: Rename To RITOBIN',
             'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="py2ritobin" -src="%V"'
+        },
+        'RitobinToPyDir': {
+            'desc': 'ritobin: Rename All RITOBIN To PY',
+            'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="ritobin2py" -src="%V"'
+        },
+        'RitobinToPy': {
+            'desc': 'ritobin: Rename To PY',
+            'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="ritobin2py" -src="%V"'
         },
         'LFI': {
             'desc': 'file_inspector: Print infos as JSON',

--- a/src/LtMAO/winLT.py
+++ b/src/LtMAO/winLT.py
@@ -44,6 +44,12 @@ class Context:
         'py': {
             'RitobinToBin': True,
         },
+        'rito': {
+            'RitobinToBin': True,
+        },
+        'ritobin': {
+            'RitobinToBin': True,
+        },
         'skl': {
             'hashextract': True,
             'LFI': True,

--- a/src/LtMAO/winLT.py
+++ b/src/LtMAO/winLT.py
@@ -49,11 +49,11 @@ class Context:
         },
         'rito': {
             'RitobinToBin': True,
-            'RitobinToPy': True,
+            'Ritobin2Py': True,
         },
         'ritobin': {
             'RitobinToBin': True,
-            'RitobinToPy': True,
+            'Ritobin2Py': True,
         },
         'skl': {
             'hashextract': True,
@@ -159,7 +159,7 @@ class Context:
             'desc': 'ritobin: Rename All RITOBIN To PY',
             'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="ritobin2py" -src="%V"'
         },
-        'RitobinToPy': {
+        'Ritobin2Py': {
             'desc': 'ritobin: Rename To PY',
             'value': f'"{os.path.abspath(python_file)}" "{os.path.abspath(cli_file)}" -t="ritobin2py" -src="%V"'
         },

--- a/src/cli.py
+++ b/src/cli.py
@@ -145,6 +145,25 @@ class CLI:
                         os.rename(old_path, new_path)
 
     @staticmethod
+    def ritobin2py(src, dst):
+        from LtMAO import lepath
+        import os
+
+        if os.path.isfile(src):
+            if src.lower().endswith(('.rito', '.ritobin')):
+                os.rename(src, lepath.ext(src, os.path.splitext(src)[1], '.py'))
+            return
+
+        if os.path.isdir(src):
+            for root, dirs, files in os.walk(src):
+                for file in files:
+                    if file.lower().endswith(('.rito', '.ritobin')):
+                        old_path = os.path.join(root, file)
+                        ext = os.path.splitext(file)[1]
+                        new_path = lepath.ext(old_path, ext, '.py')
+                        os.rename(old_path, new_path)
+
+    @staticmethod
     def lfi(src):
         from LtMAO import hash_helper, file_inspector
         hash_helper.Storage.read_all_hashes()
@@ -432,6 +451,7 @@ def main():
         'ritobindir2py':    lambda src, dst: CLI.ritobindir(src, dst, True),
         'ritobindir2bin':   lambda src, dst: CLI.ritobindir(src, dst, False),
         'py2ritobin':       lambda src, dst: CLI.py2ritobin(src, dst),
+        'ritobin2py':       lambda src, dst: CLI.ritobin2py(src, dst),
 
         'lfi':              lambda src, dst: CLI.lfi(src),
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -126,6 +126,23 @@ class CLI:
                             file_pairs.extend((py_file, bin_file))
             tools.RITOBIN.run(file_pairs)
             
+    @staticmethod
+    def py2ritobin(src, dst):
+        from LtMAO import lepath
+        import os
+
+        if os.path.isfile(src):
+            if src.lower().endswith('.py'):
+                os.rename(src, lepath.ext(src, '.py', '.ritobin'))
+            return
+
+        if os.path.isdir(src):
+            for root, dirs, files in os.walk(src):
+                for file in files:
+                    if file.lower().endswith('.py'):
+                        old_path = os.path.join(root, file)
+                        new_path = lepath.ext(old_path, '.py', '.ritobin')
+                        os.rename(old_path, new_path)
 
     @staticmethod
     def lfi(src):
@@ -414,6 +431,7 @@ def main():
         'ritobin':          lambda src, dst: CLI.ritobin(src, dst),
         'ritobindir2py':    lambda src, dst: CLI.ritobindir(src, dst, True),
         'ritobindir2bin':   lambda src, dst: CLI.ritobindir(src, dst, False),
+        'py2ritobin':       lambda src, dst: CLI.py2ritobin(src, dst),
 
         'lfi':              lambda src, dst: CLI.lfi(src),
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -102,12 +102,20 @@ class CLI:
             file_pairs = []
             for root, dirs, files in os.walk(src):
                 for file in files:
-                    # py to bin
-                    if file.endswith('.py'):
+                    # py to bin OR ritobin to bin OR rito to bin
+                    if file.endswith('.py') or file.endswith('.ritobin') or file.endswith('.rito'):
                         if file.endswith('.cdtb.py'):
                             py_file = lepath.join(root, file)
                             bin_file = lepath.ext(py_file, '.cdtb.py', '')
                             file_pairs.extend((py_file, bin_file))
+                        elif file.endswith('.ritobin'):
+                            ritobin_file = lepath.join(root, file)
+                            bin_file = lepath.ext(ritobin_file, '.ritobin', '.bin')
+                            file_pairs.extend((ritobin_file, bin_file))
+                        elif file.endswith('.rito'):
+                            rito_file = lepath.join(root, file)
+                            bin_file = lepath.ext(rito_file, '.rito', '.bin')
+                            file_pairs.extend((rito_file, bin_file))
                         else:
                             py_file = lepath.join(root, file)
                             bin_file = lepath.ext(py_file, '.py', '.bin')

--- a/src/cli.py
+++ b/src/cli.py
@@ -61,22 +61,26 @@ class CLI:
     @staticmethod
     def ritobin(src, dst):
         from LtMAO import lepath, hash_helper, pyRitoFile, tools
-        dst = None
-        # py to bin
-        if src.endswith('.py'):
-            if src.endswith('.cdtb.py'):
-                dst = lepath.ext(src, '.cdtb.py', '')
-            else:
-                dst = lepath.ext(src, '.py', '.bin')
-            tools.RITOBIN.run((src, dst))
-            return
-        # bin to py
-        elif src.endswith('.bin'):
+
+        src_lower = src.lower()
+
+        if src_lower.endswith('.cdtb.py'):
+            dst = lepath.ext(src, '.cdtb.py', '')
+        elif src_lower.endswith('.py'):
+            dst = lepath.ext(src, '.py', '.bin')
+        elif src_lower.endswith(('.ritobin', '.rito')):
+            ext = '.ritobin' if src_lower.endswith('.ritobin') else '.rito'
+            dst = lepath.ext(src, ext, '.bin')
+        elif src_lower.endswith('.bin'):
             dst = lepath.ext(src, '.bin', '.py')
         else:
             with pyRitoFile.stream.BytesStream.reader(src) as bs:
                 if pyRitoFile.wad.WADExtensioner.guess_extension(bs.read(20)) == 'bin':
                     dst = src + '.cdtb.py'
+
+        if dst is None:
+            raise ValueError(f'Could not determine output filename for: {src}')
+
         tools.RITOBIN.run((src, dst), dir_hashes=hash_helper.CustomHashes.local_dir)
         
     @staticmethod


### PR DESCRIPTION
As of Patch 26.17 Pyntex stopped working correctly because Riot changed some paths [from "string" to "file"](https://i.imgur.com/jrYHrOU.png)

**Changes:**
- Fixed Pyntex to also look for paths that are written as ' file ' and not just ' string ' . Previously the parser would show those paths as junk.

- Added .rito and .ritobin files for pyToBin converter (for [ritobin-lsp](https://github.com/alanpq/ritobin-lsp) users).
